### PR TITLE
TRN-414 complete patch with tests passing.

### DIFF
--- a/config.go
+++ b/config.go
@@ -60,6 +60,7 @@ type WalkerConfig struct {
 		ActiveFetchersKeepratio  float32  `yaml:"active_fetchers_keepratio"`
 		HttpKeepAlive            string   `yaml:"http_keep_alive"`
 		HttpKeepAliveThreshold   string   `yaml:"http_keep_alive_threshold"`
+		MaxPathLength            int      `yaml:"max_path_length"`
 	} `yaml:"fetcher"`
 
 	Dispatcher struct {
@@ -138,6 +139,7 @@ func SetDefaultConfig() {
 	Config.Fetcher.ActiveFetchersKeepratio = 0.75
 	Config.Fetcher.HttpKeepAlive = "always"
 	Config.Fetcher.HttpKeepAliveThreshold = "15s"
+	Config.Fetcher.MaxPathLength = 2048
 
 	Config.Dispatcher.MaxLinksPerSegment = 500
 	Config.Dispatcher.RefreshPercentage = 25

--- a/fetcher.go
+++ b/fetcher.go
@@ -679,10 +679,17 @@ func (f *fetcher) fetch(u *URL) (*http.Response, []*URL, error) {
 
 // shouldStoreParsedLink returns true if the argument URL should
 // be stored in datastore. The link can (currently) be rejected
-// because it's not in the AcceptProtocols, or if the path matches
-// exclude_link_patterns and doesn't match include_link_patterns
+// because
+//   (*) it's not in the AcceptProtocols
+//   (*) if the path matches exclude_link_patterns and doesn't match include_link_patterns.
+//   (*) the link's path is longer than (the positive) Config.Fetcher.MaxPathLength variable
+//
 func (f *fetcher) shouldStoreParsedLink(u *URL) bool {
 	path := u.RequestURI()
+	if Config.Fetcher.MaxPathLength > 0 && len(path) > Config.Fetcher.MaxPathLength {
+		return false
+	}
+
 	include := !(f.excludeLink != nil && f.excludeLink.MatchString(path)) ||
 		(f.includeLink != nil && f.includeLink.MatchString(path))
 	if !include {

--- a/test/fetcher_test.go
+++ b/test/fetcher_test.go
@@ -1787,7 +1787,6 @@ func TestParseHttpEquiv(t *testing.T) {
 </head>
 <body>
 Some text here.
->>>>>>> master
 </body>
 </html>`
 

--- a/walker.yaml
+++ b/walker.yaml
@@ -104,9 +104,10 @@ fetcher:
     # this variable is unused.
     http_keep_alive_threshold: 15s
 
-    # The maximum path length that is considered a good url. URL's with paths longer than this will not be crawled. This
-    # variable helps users prevent cycles (where a web-page refers to itself, only with a slightly longer, and hence 
-    # distinct, URI). Set this variable <= 0 to ignore URI path length.
+    # The maximum path length that is considered a good url. URL's with paths longer than this will be completely
+    # ignored: i.e. not crawled, not inserted into the datastore, etc. This variable helps users prevent cycles (where a
+    # web-page refers to itself, only with a slightly longer, and hence  distinct, URI). Set this variable <= 0 to
+    # ignore URI path length.
     max_path_length: 2048
 
 # Dispatcher configuration

--- a/walker.yaml
+++ b/walker.yaml
@@ -104,6 +104,11 @@ fetcher:
     # this variable is unused.
     http_keep_alive_threshold: 15s
 
+    # The maximum path length that is considered a good url. URL's with paths longer than this will not be crawled. This
+    # variable helps users prevent cycles (where a web-page refers to itself, only with a slightly longer, and hence 
+    # distinct, URI). Set this variable <= 0 to ignore URI path length.
+    max_path_length: 2048
+
 # Dispatcher configuration
 dispatcher:
     # maximum number of links added to segments table per dispatch (must be >0)


### PR DESCRIPTION
Ticket found at https://jira2.iparadigms.com/browse/TRN-414
<ticket>
The following list of links/domains each have some kind of endless repeating behavior that makes them useless for us to crawl. Thus these domains are disabled; we only really want to crawl them if we're not going to get junk. These can also be found at https://confluence.iparadigms.com/display/SEU/Walker+Project+Plan
For each one:
Explore whether it's the target site's problem or how we are parsing their links
If we can parse better so that we will no longer have an issue on the site, implement the fix; due to link filtration some of these may no longer be a problem, but at least write a test to verify that
Create a separate story for all "fixed" sites; we'll need to reenable them but in most cases we will probably also want to clear out the bad data too (and remove them from the wiki page)
For sites we cannot fix, update the exclude_reason on those domains to explain why they are excluded
....
</ticket>