### PR TITLE
TRN-334a Historical link

### DIFF
--- a/console/controllers.go
+++ b/console/controllers.go
@@ -607,6 +607,7 @@ func LinksHistoricalController(w http.ResponseWriter, req *http.Request) {
 	}
 
 	mp := map[string]interface{}{
+		"Domain":    u.Host,
 		"LinkTopic": u.String(),
 		"Linfos":    linfos,
 	}

--- a/console/templates/historical.tmpl
+++ b/console/templates/historical.tmpl
@@ -1,7 +1,8 @@
 
 
  <div class="row" style="width: 90%;">
-        <h2> History for Link <a href="{{.LinkTopic}}" target="_blank" title="visit link">{{.LinkTopic}}</a></h2>
+        <h2>History for Link <a href="{{.LinkTopic}}" target="_blank" title="visit link">{{.LinkTopic}}</a></h2>
+        <h3><a href="/links/{{.Domain}}" title="view domain info">Domain Info</a></h3>
         <table class="console-table table table-striped table-condensed">
             <thead>
                 <th class="col-xs-3"> Fetched On </th>

--- a/console/templates/historical.tmpl
+++ b/console/templates/historical.tmpl
@@ -1,7 +1,7 @@
 
 
  <div class="row" style="width: 90%;">
-        <h2> History for Link {{.LinkTopic}} </h2>
+        <h2> History for Link <a href="{{.LinkTopic}}" target="_blank" title="visit link">{{.LinkTopic}}</a></h2>
         <table class="console-table table table-striped table-condensed">
             <thead>
                 <th class="col-xs-3"> Fetched On </th>

--- a/console/test/controllers_test.go
+++ b/console/test/controllers_test.go
@@ -663,6 +663,13 @@ func TestListHistorical(t *testing.T) {
 		}
 	})
 
+	doc.Find(".container h2 a").First().Each(func(index int, sel *goquery.Selection) {
+		text := strings.TrimSpace(sel.Text())
+		if !strings.HasPrefix(text, "http://") {
+			t.Fatalf("[.container h2 a] Bad prefix got %s, expected 'http://'", text)
+		}
+	})
+
 	tables = doc.Find(".container table")
 	if tables.Size() != 1 {
 		t.Fatalf("[.container table] Bad size got %d, expected %d", tables.Size(), 1)

--- a/console/test/controllers_test.go
+++ b/console/test/controllers_test.go
@@ -663,6 +663,13 @@ func TestListHistorical(t *testing.T) {
 		}
 	})
 
+	doc.Find(".container h3 a").First().Each(func(index int, sel *goquery.Selection) {
+		text := strings.TrimSpace(sel.Text())
+		if !strings.HasPrefix(text, "Domain Info") {
+			t.Fatalf("[.container h3 a] Bad prefix got %s, expected 'Domain Info'", text)
+		}
+	})
+
 	doc.Find(".container h2 a").First().Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if !strings.HasPrefix(text, "http://") {


### PR DESCRIPTION
From the ticket:
* When looking at the /historical/... info page for a link, the link header itself should lead to the target site and there should be a link to get to the domain info page for that link

This is completed now, the tests pass and I've reviewed it visually as well. Let me know, there may be a style guide for the UI and if so I may be to adjust the way I have the link to domain info displayed.