### PR TITLE
TRN-334b 

### DIFF
--- a/console/controllers.go
+++ b/console/controllers.go
@@ -607,6 +607,7 @@ func LinksHistoricalController(w http.ResponseWriter, req *http.Request) {
 	}
 
 	mp := map[string]interface{}{
+		"Domain":    u.Host,
 		"LinkTopic": u.String(),
 		"Linfos":    linfos,
 	}

--- a/console/templates/historical.tmpl
+++ b/console/templates/historical.tmpl
@@ -1,7 +1,8 @@
 
 
  <div class="row" style="width: 90%;">
-        <h2> History for Link <a href="{{.LinkTopic}}" target="_blank" title="visit link">{{.LinkTopic}}</a></h2>
+        <h2>History for Link <a href="{{.LinkTopic}}" target="_blank" title="visit link">{{.LinkTopic}}</a></h2>
+        <h3><a href="/links/{{.Domain}}" title="view domain info">Domain Info</a></h3>
         <table class="console-table table table-striped table-condensed">
             <thead>
                 <th class="col-xs-3"> Fetched On </th>

--- a/console/templates/historical.tmpl
+++ b/console/templates/historical.tmpl
@@ -1,7 +1,7 @@
 
 
  <div class="row" style="width: 90%;">
-        <h2> History for Link {{.LinkTopic}} </h2>
+        <h2> History for Link <a href="{{.LinkTopic}}" target="_blank" title="visit link">{{.LinkTopic}}</a></h2>
         <table class="console-table table table-striped table-condensed">
             <thead>
                 <th class="col-xs-3"> Fetched On </th>

--- a/console/templates/links.tmpl
+++ b/console/templates/links.tmpl
@@ -129,9 +129,13 @@
     <div class="row" style="width: 90%;">
         <div class="col-xs-6">
             {{if .AltTitle}}
-                <h2> Searched for links </h2>
+                <h2>Searched for links </h2>
             {{else}}
-                <h2> Links for domain {{.Dinfo.Domain}} {{.FilterRegexSuffix}}</h2>
+                {{if .HasHeader}}
+                    <h2>Links for domain {{.Dinfo.Domain}} {{.FilterRegexSuffix}}</h2>
+                {{else}}
+                    <h2>Links for domain <a href="/links/{{.Dinfo.Domain}}" title="view domain info">{{.Dinfo.Domain}} {{.FilterRegexSuffix}}<a/></h2>
+                {{end}}
             {{end}}
         </div>
         <div class="col-xs-3">

--- a/console/test/controllers_test.go
+++ b/console/test/controllers_test.go
@@ -493,6 +493,23 @@ func TestListLinksSecondPage(t *testing.T) {
 		t.FailNow()
 	}
 
+	// Test the h2 is a link to the domain info page
+	doc.Find(".container h2 a").First().Each(func(index int, sel *goquery.Selection) {
+		text := strings.TrimSpace(sel.Text())
+		if !strings.HasPrefix(text, "Domain Info") {
+			t.Fatalf("[.container h3 a] Bad prefix got %s, expected 'Domain Info'", text)
+		}
+		link, linkOk := sel.Attr("href")
+		if !linkOk {
+			t.Errorf("[.container h2 a] Failed to find href attribute in the h2")
+			return
+		}
+		if !strings.HasPrefix(link, "/links") {
+			t.Fatalf("[.container h2 a] Failed to find prefix /links in href (%s)", link)
+			return
+		}
+	})
+
 	nextButton := doc.Find(".container a").FilterFunction(func(index int, sel *goquery.Selection) bool {
 		return sel.HasClass("btn") && strings.Contains(sel.Text(), "Next")
 	})

--- a/console/test/controllers_test.go
+++ b/console/test/controllers_test.go
@@ -663,6 +663,13 @@ func TestListHistorical(t *testing.T) {
 		}
 	})
 
+	doc.Find(".container h2 a").First().Each(func(index int, sel *goquery.Selection) {
+		text := strings.TrimSpace(sel.Text())
+		if !strings.HasPrefix(text, "http://") {
+			t.Fatalf("[.container h2 a] Bad prefix got %s, expected 'http://'", text)
+		}
+	})
+
 	tables = doc.Find(".container table")
 	if tables.Size() != 1 {
 		t.Fatalf("[.container table] Bad size got %d, expected %d", tables.Size(), 1)

--- a/console/test/controllers_test.go
+++ b/console/test/controllers_test.go
@@ -663,6 +663,13 @@ func TestListHistorical(t *testing.T) {
 		}
 	})
 
+	doc.Find(".container h3 a").First().Each(func(index int, sel *goquery.Selection) {
+		text := strings.TrimSpace(sel.Text())
+		if !strings.HasPrefix(text, "Domain Info") {
+			t.Fatalf("[.container h3 a] Bad prefix got %s, expected 'Domain Info'", text)
+		}
+	})
+
 	doc.Find(".container h2 a").First().Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if !strings.HasPrefix(text, "http://") {


### PR DESCRIPTION
From the ticket TRN-334:
* When paging through links in a domain, there should be a link to return to the domain info page

On second and subsequent pages of links the domain header links back to the domain info page.