### PR TITLE
Feature trn 334 extra nav

### DIFF
--- a/console/controllers.go
+++ b/console/controllers.go
@@ -405,9 +405,22 @@ func AddLinkIndexController(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	type HistoryLink struct {
+		URL         string
+		HistoryPath string
+	}
+	var historyLinks []HistoryLink
+	for _, link := range links {
+		h := HistoryLink{
+			URL:         link,
+			HistoryPath: "/historical/" + encode32(link),
+		}
+		historyLinks = append(historyLinks, h)
+	}
+	// build up links to historical page for each link
 	mp := map[string]interface{}{
-		"HasInfoMessage": true,
-		"InfoMessage":    []string{"All links added"},
+		"HasInfoMessage": false, // the default ul format makes no sense here
+		"HLinks":         historyLinks,
 	}
 	Render.HTML(w, http.StatusOK, "add", mp)
 	return

--- a/console/controllers.go
+++ b/console/controllers.go
@@ -607,6 +607,7 @@ func LinksHistoricalController(w http.ResponseWriter, req *http.Request) {
 	}
 
 	mp := map[string]interface{}{
+		"Domain":    u.Host,
 		"LinkTopic": u.String(),
 		"Linfos":    linfos,
 	}

--- a/console/controllers.go
+++ b/console/controllers.go
@@ -605,9 +605,13 @@ func LinksHistoricalController(w http.ResponseWriter, req *http.Request) {
 		replyServerError(w, fmt.Errorf("ListLinkHistorical (%v): %v", u, err))
 		return
 	}
-
+	domain, err := u.ToplevelDomainPlusOne()
+	if err != nil {
+		replyServerError(w, fmt.Errorf("ListLinkHistorical - ToplevelDomainPlusOne (%v): %v", u, err))
+		return
+	}
 	mp := map[string]interface{}{
-		"Domain":    u.Host,
+		"Domain":    domain,
 		"LinkTopic": u.String(),
 		"Linfos":    linfos,
 	}

--- a/console/templates/add.tmpl
+++ b/console/templates/add.tmpl
@@ -1,3 +1,11 @@
+{{ if .HLinks}}
+    <h2 class="status">Links Added</h2>
+    <ul>
+        {{range .HLinks}}
+            <li class="info-li"><a href="{{.HistoryPath}}" title="view link history">{{.URL}}</a></li>
+        {{end}}
+    </ul>
+{{end}}
 <h2>Add Links</h2>
 
 <!-- This styling makes the checkbox bigger, and orients the h3 text  -->
@@ -42,6 +50,5 @@
         </div>
     </div>
 </form>
-
 
 

--- a/console/templates/historical.tmpl
+++ b/console/templates/historical.tmpl
@@ -1,7 +1,8 @@
 
 
  <div class="row" style="width: 90%;">
-        <h2> History for Link <a href="{{.LinkTopic}}" target="_blank" title="visit link">{{.LinkTopic}}</a></h2>
+        <h2>History for Link <a href="{{.LinkTopic}}" target="_blank" title="visit link">{{.LinkTopic}}</a></h2>
+        <h3><a href="/links/{{.Domain}}" title="view domain info">Domain Info</a></h3>
         <table class="console-table table table-striped table-condensed">
             <thead>
                 <th class="col-xs-3"> Fetched On </th>

--- a/console/templates/historical.tmpl
+++ b/console/templates/historical.tmpl
@@ -1,7 +1,7 @@
 
 
  <div class="row" style="width: 90%;">
-        <h2> History for Link {{.LinkTopic}} </h2>
+        <h2> History for Link <a href="{{.LinkTopic}}" target="_blank" title="visit link">{{.LinkTopic}}</a></h2>
         <table class="console-table table table-striped table-condensed">
             <thead>
                 <th class="col-xs-3"> Fetched On </th>

--- a/console/templates/links.tmpl
+++ b/console/templates/links.tmpl
@@ -129,9 +129,13 @@
     <div class="row" style="width: 90%;">
         <div class="col-xs-6">
             {{if .AltTitle}}
-                <h2> Searched for links </h2>
+                <h2>Searched for links </h2>
             {{else}}
-                <h2> Links for domain {{.Dinfo.Domain}} {{.FilterRegexSuffix}}</h2>
+                {{if .HasHeader}}
+                    <h2>Links for domain {{.Dinfo.Domain}} {{.FilterRegexSuffix}}</h2>
+                {{else}}
+                    <h2>Links for domain <a href="/links/{{.Dinfo.Domain}}" title="view domain info">{{.Dinfo.Domain}} {{.FilterRegexSuffix}}<a/></h2>
+                {{end}}
             {{end}}
         </div>
         <div class="col-xs-3">

--- a/console/test/controllers_test.go
+++ b/console/test/controllers_test.go
@@ -493,6 +493,23 @@ func TestListLinksSecondPage(t *testing.T) {
 		t.FailNow()
 	}
 
+	// Test the h2 is a link to the domain info page
+	doc.Find(".container h2 a").First().Each(func(index int, sel *goquery.Selection) {
+		text := strings.TrimSpace(sel.Text())
+		if !strings.HasPrefix(text, "Domain Info") {
+			t.Fatalf("[.container h3 a] Bad prefix got %s, expected 'Domain Info'", text)
+		}
+		link, linkOk := sel.Attr("href")
+		if !linkOk {
+			t.Errorf("[.container h2 a] Failed to find href attribute in the h2")
+			return
+		}
+		if !strings.HasPrefix(link, "/links") {
+			t.Fatalf("[.container h2 a] Failed to find prefix /links in href (%s)", link)
+			return
+		}
+	})
+
 	nextButton := doc.Find(".container a").FilterFunction(func(index int, sel *goquery.Selection) bool {
 		return sel.HasClass("btn") && strings.Contains(sel.Text(), "Next")
 	})

--- a/console/test/controllers_test.go
+++ b/console/test/controllers_test.go
@@ -663,6 +663,13 @@ func TestListHistorical(t *testing.T) {
 		}
 	})
 
+	doc.Find(".container h2 a").First().Each(func(index int, sel *goquery.Selection) {
+		text := strings.TrimSpace(sel.Text())
+		if !strings.HasPrefix(text, "http://") {
+			t.Fatalf("[.container h2 a] Bad prefix got %s, expected 'http://'", text)
+		}
+	})
+
 	tables = doc.Find(".container table")
 	if tables.Size() != 1 {
 		t.Fatalf("[.container table] Bad size got %d, expected %d", tables.Size(), 1)

--- a/console/test/controllers_test.go
+++ b/console/test/controllers_test.go
@@ -1025,15 +1025,11 @@ func TestAddLinks(t *testing.T) {
 		t.Log(body)
 		t.FailNow()
 	}
-	res := doc.Find(".container > ul li")
-	if res.Size() != 1 {
-		t.Fatalf("[.container > ul li] Size mismatch got %d, expected 1", res.Size())
-	}
+	res := doc.Find(".container h2.status")
 	res.Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
-		e := "All links added"
-		if text != e {
-			t.Fatalf("[.container ul li] Mismatched text got '%v', expected '%v'", text, e)
+		if !strings.HasPrefix(text, "Links Added") {
+			t.Fatalf("[.container h2] Mismatched text got '%v', expected 'Links Added'", text)
 		}
 	})
 

--- a/console/test/controllers_test.go
+++ b/console/test/controllers_test.go
@@ -663,6 +663,13 @@ func TestListHistorical(t *testing.T) {
 		}
 	})
 
+	doc.Find(".container h3 a").First().Each(func(index int, sel *goquery.Selection) {
+		text := strings.TrimSpace(sel.Text())
+		if !strings.HasPrefix(text, "Domain Info") {
+			t.Fatalf("[.container h3 a] Bad prefix got %s, expected 'Domain Info'", text)
+		}
+	})
+
 	doc.Find(".container h2 a").First().Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if !strings.HasPrefix(text, "http://") {

--- a/console/test/controllers_test.go
+++ b/console/test/controllers_test.go
@@ -129,12 +129,12 @@ func TestLayout(t *testing.T) {
 		found, foundOk := mainLinks[link]
 
 		if !foundOk {
-			t.Errorf("[nav ul li a] Failed to find link '%q' in menu list", link)
+			t.Errorf("[nav ul li a] Failed to find link %q in menu list", link)
 			return
 		}
 
 		if found != text {
-			t.Errorf("[nav ul li a] Text mismatch for %q: got '%q', expected '%q'", link, text, found)
+			t.Errorf("[nav ul li a] Text mismatch for %q: got %q, expected %q", link, text, found)
 			return
 		}
 
@@ -212,7 +212,7 @@ func TestHome(t *testing.T) {
 		text := strings.TrimSpace(sel.Text())
 		exp := "Walker Console"
 		if !strings.Contains(text, exp) {
-			t.Errorf("[.container p] <p> mismatch: got '%q', expected to contain '%q'", text, exp)
+			t.Errorf("[.container p] <p> mismatch: got %q, expected to contain %q", text, exp)
 		}
 	})
 }
@@ -320,7 +320,7 @@ func TestListLinksWeb(t *testing.T) {
 	sub.Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != h2[count] {
-			t.Fatalf("[.container h2] Text mismatch got '%q', expected '%q'", text, h2[count])
+			t.Fatalf("[.container h2] Text mismatch got %q, expected %q", text, h2[count])
 		}
 
 		count++
@@ -357,7 +357,7 @@ func TestListLinksWeb(t *testing.T) {
 	sub.Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != domainKeys[count] {
-			t.Fatalf("[.container table tr > td:nth-child(1)] Column key mismatch '%q', expected '%q'", text, domainKeys[count])
+			t.Fatalf("[.container table tr > td:nth-child(1)] Column key mismatch %q, expected %q", text, domainKeys[count])
 		}
 
 		count++
@@ -392,7 +392,7 @@ func TestListLinksWeb(t *testing.T) {
 	sub.Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != linksColHeaders[count] {
-			t.Fatalf("[.container table thead th] Col name mismatch got '%q', expected '%q'", text, linksColHeaders[count])
+			t.Fatalf("[.container table thead th] Col name mismatch got %q, expected %q", text, linksColHeaders[count])
 		}
 
 		count++
@@ -431,7 +431,7 @@ func TestListLinksWeb(t *testing.T) {
 	sub.Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != buttons[count] {
-			t.Fatalf("[.container .row > a <buttons>] Button text mismatch got '%q', expected '%q'", text, buttons[count])
+			t.Fatalf("[.container .row > a <buttons>] Button text mismatch got %q, expected %q", text, buttons[count])
 		}
 
 		if text == "Previous" {
@@ -557,7 +557,7 @@ func TestListLinksSecondPage(t *testing.T) {
 	sub.Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != linksColHeaders[count] {
-			t.Fatalf("[.container table thead th] Col name mismatch got '%q', expected '%q'", text, linksColHeaders[count])
+			t.Fatalf("[.container table thead th] Col name mismatch got %q, expected %q", text, linksColHeaders[count])
 		}
 
 		count++
@@ -597,7 +597,7 @@ func TestListLinksSecondPage(t *testing.T) {
 	sub.Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != buttons[count] {
-			t.Fatalf("[.container a <buttons>] Failed text got '%q', expected '%q'", text, buttons[count])
+			t.Fatalf("[.container a <buttons>] Failed text got %q, expected %q", text, buttons[count])
 		}
 
 		if text == "Previous" {
@@ -710,7 +710,7 @@ func TestListHistorical(t *testing.T) {
 	tables.Find("thead th").Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != colHeaders[count] {
-			t.Fatalf("[.container table thead th] Column header got '%q', expected '%q'", text, colHeaders[count])
+			t.Fatalf("[.container table thead th] Column header got %q, expected %q", text, colHeaders[count])
 		}
 
 		count++
@@ -745,7 +745,7 @@ func TestFindDomains(t *testing.T) {
 	doc.Find(".container h2").Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != "Find domains" {
-			t.Errorf("[.container h2] H2 mismatch got '%q', expected '%q'", text, "Find domains")
+			t.Errorf("[.container h2] H2 mismatch got %q, expected %q", text, "Find domains")
 		}
 	})
 
@@ -773,7 +773,7 @@ func TestFindDomains(t *testing.T) {
 	if !typOk {
 		t.Fatalf("[.container form input] Failed to find type attribute")
 	} else if typ != "submit" {
-		t.Fatalf("[.container form input] Type mismatch got '%q', expected 'submit'", typ)
+		t.Fatalf("[.container form input] Type mismatch got %q, expected 'submit'", typ)
 	}
 
 	//
@@ -859,7 +859,7 @@ func TestFindDomains(t *testing.T) {
 	text := strings.TrimSpace(sub.Text())
 	etext := "Failed to specify any targets"
 	if text != etext {
-		t.Fatalf("[.info-li] Error message mismatch: got '%q', expected '%q'", text, etext)
+		t.Fatalf("[.info-li] Error message mismatch: got %q, expected %q", text, etext)
 	}
 
 	//
@@ -880,7 +880,7 @@ func TestFindDomains(t *testing.T) {
 	text = strings.TrimSpace(sub.Text())
 	etext = "Failed to specify any targets"
 	if text != etext {
-		t.Fatalf("[.info-li] Error message mismatch: got '%q', expected '%q'", text, etext)
+		t.Fatalf("[.info-li] Error message mismatch: got %q, expected %q", text, etext)
 	}
 }
 
@@ -900,7 +900,7 @@ func TestFindLinks(t *testing.T) {
 	doc.Find(".container h2").Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != "Find Links" {
-			t.Errorf("[.container h2] Header mismatch got '%q', expected '%q'", text, "Find Links")
+			t.Errorf("[.container h2] Header mismatch got %q, expected %q", text, "Find Links")
 		}
 	})
 
@@ -928,7 +928,7 @@ func TestFindLinks(t *testing.T) {
 	if !typOk {
 		t.Fatalf("[.container form input] Failed to find type attribute")
 	} else if typ != "submit" {
-		t.Fatalf("[.container form input] Type mismatch got '%q', expected 'submit'", typ)
+		t.Fatalf("[.container form input] Type mismatch got %q, expected 'submit'", typ)
 	}
 
 	//
@@ -972,7 +972,7 @@ func TestAddLinks(t *testing.T) {
 		text := strings.TrimSpace(sel.Text())
 		e := "Add Links"
 		if text != e {
-			t.Fatalf("[.container h2] Header mismatch got '%q', expected '%q'", text, e)
+			t.Fatalf("[.container h2] Header mismatch got %q, expected %q", text, e)
 		}
 	})
 
@@ -1017,7 +1017,7 @@ func TestAddLinks(t *testing.T) {
 	// Submit an add request
 	//
 	randDomain := fmt.Sprintf("rand%d.com", rand.Uint32())
-	randLink := fmt.Sprintf("http://sub.%q.com/page0.html", randDomain)
+	randLink := fmt.Sprintf("http://sub.%s.com/page0.html", randDomain)
 	rawBody := "links=" + randLink + "%0D%0A"
 	doc, body, status = callController("http://localhost:3000/add", rawBody, "/add", console.AddLinkIndexController)
 	if status != http.StatusOK {

--- a/console/test/controllers_test.go
+++ b/console/test/controllers_test.go
@@ -129,12 +129,12 @@ func TestLayout(t *testing.T) {
 		found, foundOk := mainLinks[link]
 
 		if !foundOk {
-			t.Errorf("[nav ul li a] Failed to find link '%s' in menu list", link)
+			t.Errorf("[nav ul li a] Failed to find link '%q' in menu list", link)
 			return
 		}
 
 		if found != text {
-			t.Errorf("[nav ul li a] Text mismatch for %s: got '%s', expected '%s'", link, text, found)
+			t.Errorf("[nav ul li a] Text mismatch for %q: got '%q', expected '%q'", link, text, found)
 			return
 		}
 
@@ -159,7 +159,7 @@ func TestLayout(t *testing.T) {
 			return
 		}
 		if !cssLinks[link] {
-			t.Errorf("[head link] Failed to find link %s", link)
+			t.Errorf("[head link] Failed to find link %q", link)
 			return
 		}
 
@@ -184,7 +184,7 @@ func TestLayout(t *testing.T) {
 			return
 		}
 		if !jsLinks[link] {
-			t.Errorf("[head script] Failed to find link %s", link)
+			t.Errorf("[head script] Failed to find link %q", link)
 			return
 		}
 
@@ -212,7 +212,7 @@ func TestHome(t *testing.T) {
 		text := strings.TrimSpace(sel.Text())
 		exp := "Walker Console"
 		if !strings.Contains(text, exp) {
-			t.Errorf("[.container p] <p> mismatch: got '%s', expected to contain '%s'", text, exp)
+			t.Errorf("[.container p] <p> mismatch: got '%q', expected to contain '%q'", text, exp)
 		}
 	})
 }
@@ -320,7 +320,7 @@ func TestListLinksWeb(t *testing.T) {
 	sub.Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != h2[count] {
-			t.Fatalf("[.container h2] Text mismatch got '%s', expected '%s'", text, h2[count])
+			t.Fatalf("[.container h2] Text mismatch got '%q', expected '%q'", text, h2[count])
 		}
 
 		count++
@@ -357,7 +357,7 @@ func TestListLinksWeb(t *testing.T) {
 	sub.Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != domainKeys[count] {
-			t.Fatalf("[.container table tr > td:nth-child(1)] Column key mismatch '%s', expected '%s'", text, domainKeys[count])
+			t.Fatalf("[.container table tr > td:nth-child(1)] Column key mismatch '%q', expected '%q'", text, domainKeys[count])
 		}
 
 		count++
@@ -365,7 +365,7 @@ func TestListLinksWeb(t *testing.T) {
 
 	secondColSize := domainTable.Find("tr > td:nth-child(2)").Size()
 	if secondColSize != len(domainKeys) {
-		t.Fatalf("[.container table tr > td:nth-child(2)] Second column mismatch got %d, expected %s", secondColSize, len(domainKeys))
+		t.Fatalf("[.container table tr > td:nth-child(2)] Second column mismatch got %d, expected %q", secondColSize, len(domainKeys))
 	}
 
 	thirdColSize := domainTable.Find("tr > td:nth-child(3)").Size()
@@ -392,7 +392,7 @@ func TestListLinksWeb(t *testing.T) {
 	sub.Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != linksColHeaders[count] {
-			t.Fatalf("[.container table thead th] Col name mismatch got '%s', expected '%s'", text, linksColHeaders[count])
+			t.Fatalf("[.container table thead th] Col name mismatch got '%q', expected '%q'", text, linksColHeaders[count])
 		}
 
 		count++
@@ -409,7 +409,7 @@ func TestListLinksWeb(t *testing.T) {
 			return
 		}
 		if !strings.HasPrefix(link, "/historical") {
-			t.Fatalf("[.container table tbody tr td a] Failed to find prefix /historical in href (%s)", link)
+			t.Fatalf("[.container table tbody tr td a] Failed to find prefix /historical in href (%q)", link)
 			return
 		}
 	})
@@ -431,16 +431,16 @@ func TestListLinksWeb(t *testing.T) {
 	sub.Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != buttons[count] {
-			t.Fatalf("[.container .row > a <buttons>] Button text mismatch got '%s', expected '%s'", text, buttons[count])
+			t.Fatalf("[.container .row > a <buttons>] Button text mismatch got '%q', expected '%q'", text, buttons[count])
 		}
 
 		if text == "Previous" {
 			if !sel.HasClass("disabled") {
-				t.Fatalf("[.container .row > a <buttons>] Failed button disable for %s", text)
+				t.Fatalf("[.container .row > a <buttons>] Failed button disable for %q", text)
 			}
 		} else {
 			if sel.HasClass("disabled") {
-				t.Fatalf("[.container .row > a <buttons>] Failed button undisabled for %s", text)
+				t.Fatalf("[.container .row > a <buttons>] Failed button undisabled for %q", text)
 			}
 		}
 
@@ -497,7 +497,7 @@ func TestListLinksSecondPage(t *testing.T) {
 	doc.Find(".container h2 a").First().Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if !strings.HasPrefix(text, "Domain Info") {
-			t.Fatalf("[.container h3 a] Bad prefix got %s, expected 'Domain Info'", text)
+			t.Fatalf("[.container h3 a] Bad prefix got %q, expected 'Domain Info'", text)
 		}
 		link, linkOk := sel.Attr("href")
 		if !linkOk {
@@ -505,7 +505,7 @@ func TestListLinksSecondPage(t *testing.T) {
 			return
 		}
 		if !strings.HasPrefix(link, "/links") {
-			t.Fatalf("[.container h2 a] Failed to find prefix /links in href (%s)", link)
+			t.Fatalf("[.container h2 a] Failed to find prefix /links in href (%q)", link)
 			return
 		}
 	})
@@ -557,7 +557,7 @@ func TestListLinksSecondPage(t *testing.T) {
 	sub.Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != linksColHeaders[count] {
-			t.Fatalf("[.container table thead th] Col name mismatch got '%s', expected '%s'", text, linksColHeaders[count])
+			t.Fatalf("[.container table thead th] Col name mismatch got '%q', expected '%q'", text, linksColHeaders[count])
 		}
 
 		count++
@@ -574,7 +574,7 @@ func TestListLinksSecondPage(t *testing.T) {
 			return
 		}
 		if !strings.HasPrefix(link, "/historical") {
-			t.Fatalf("[.container table tbody tr td a] Failed to find prefix /historical in href (%s)", link)
+			t.Fatalf("[.container table tbody tr td a] Failed to find prefix /historical in href (%q)", link)
 			return
 		}
 	})
@@ -597,16 +597,16 @@ func TestListLinksSecondPage(t *testing.T) {
 	sub.Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != buttons[count] {
-			t.Fatalf("[.container a <buttons>] Failed text got '%s', expected '%s'", text, buttons[count])
+			t.Fatalf("[.container a <buttons>] Failed text got '%q', expected '%q'", text, buttons[count])
 		}
 
 		if text == "Previous" {
 			if sel.HasClass("disabled") {
-				t.Fatalf("[.container a <buttons>] Failed disabled for %s", text)
+				t.Fatalf("[.container a <buttons>] Failed disabled for %q", text)
 			}
 		} else {
 			if !sel.HasClass("disabled") {
-				t.Fatalf("[.container a <buttons>] Failed disabled for %s", text)
+				t.Fatalf("[.container a <buttons>] Failed disabled for %q", text)
 			}
 		}
 
@@ -655,7 +655,7 @@ func TestListHistorical(t *testing.T) {
 			return
 		}
 		if !strings.HasPrefix(link, "/historical") {
-			t.Fatalf("[.container table tbody tr td a] Failed to find prefix /historical in href (%s)", link)
+			t.Fatalf("[.container table tbody tr td a] Failed to find prefix /historical in href (%q)", link)
 			return
 		}
 
@@ -676,21 +676,21 @@ func TestListHistorical(t *testing.T) {
 	doc.Find(".container h2").First().Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if !strings.HasPrefix(text, "History for Link") {
-			t.Fatalf("[.container h2] Bad prefix got %s, expected 'History for Link'", text)
+			t.Fatalf("[.container h2] Bad prefix got %q, expected 'History for Link'", text)
 		}
 	})
 
 	doc.Find(".container h3 a").First().Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if !strings.HasPrefix(text, "Domain Info") {
-			t.Fatalf("[.container h3 a] Bad prefix got %s, expected 'Domain Info'", text)
+			t.Fatalf("[.container h3 a] Bad prefix got %q, expected 'Domain Info'", text)
 		}
 	})
 
 	doc.Find(".container h2 a").First().Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if !strings.HasPrefix(text, "http://") {
-			t.Fatalf("[.container h2 a] Bad prefix got %s, expected 'http://'", text)
+			t.Fatalf("[.container h2 a] Bad prefix got %q, expected 'http://'", text)
 		}
 	})
 
@@ -710,7 +710,7 @@ func TestListHistorical(t *testing.T) {
 	tables.Find("thead th").Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != colHeaders[count] {
-			t.Fatalf("[.container table thead th] Column header got '%s', expected '%s'", text, colHeaders[count])
+			t.Fatalf("[.container table thead th] Column header got '%q', expected '%q'", text, colHeaders[count])
 		}
 
 		count++
@@ -745,7 +745,7 @@ func TestFindDomains(t *testing.T) {
 	doc.Find(".container h2").Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != "Find domains" {
-			t.Errorf("[.container h2] H2 mismatch got '%s', expected '%s'", text, "Find domains")
+			t.Errorf("[.container h2] H2 mismatch got '%q', expected '%q'", text, "Find domains")
 		}
 	})
 
@@ -761,7 +761,7 @@ func TestFindDomains(t *testing.T) {
 	} else {
 		e := "Enter domains: one per line"
 		if placeholder != e {
-			t.Fatalf("[.container form textarea] Bad placeholder attribute got %s, expected %s", placeholder, e)
+			t.Fatalf("[.container form textarea] Bad placeholder attribute got %q, expected %q", placeholder, e)
 		}
 	}
 
@@ -773,7 +773,7 @@ func TestFindDomains(t *testing.T) {
 	if !typOk {
 		t.Fatalf("[.container form input] Failed to find type attribute")
 	} else if typ != "submit" {
-		t.Fatalf("[.container form input] Type mismatch got '%s', expected 'submit'", typ)
+		t.Fatalf("[.container form input] Type mismatch got '%q', expected 'submit'", typ)
 	}
 
 	//
@@ -859,7 +859,7 @@ func TestFindDomains(t *testing.T) {
 	text := strings.TrimSpace(sub.Text())
 	etext := "Failed to specify any targets"
 	if text != etext {
-		t.Fatalf("[.info-li] Error message mismatch: got '%s', expected '%s'", text, etext)
+		t.Fatalf("[.info-li] Error message mismatch: got '%q', expected '%q'", text, etext)
 	}
 
 	//
@@ -880,7 +880,7 @@ func TestFindDomains(t *testing.T) {
 	text = strings.TrimSpace(sub.Text())
 	etext = "Failed to specify any targets"
 	if text != etext {
-		t.Fatalf("[.info-li] Error message mismatch: got '%s', expected '%s'", text, etext)
+		t.Fatalf("[.info-li] Error message mismatch: got '%q', expected '%q'", text, etext)
 	}
 }
 
@@ -900,7 +900,7 @@ func TestFindLinks(t *testing.T) {
 	doc.Find(".container h2").Each(func(index int, sel *goquery.Selection) {
 		text := strings.TrimSpace(sel.Text())
 		if text != "Find Links" {
-			t.Errorf("[.container h2] Header mismatch got '%s', expected '%s'", text, "Find Links")
+			t.Errorf("[.container h2] Header mismatch got '%q', expected '%q'", text, "Find Links")
 		}
 	})
 
@@ -917,7 +917,7 @@ func TestFindLinks(t *testing.T) {
 	} else {
 		e := "Enter links: one per line"
 		if placeholder != e {
-			t.Fatalf("[.container form textarea] Bad placeholder attribute got %s, expected %s", placeholder, e)
+			t.Fatalf("[.container form textarea] Bad placeholder attribute got %q, expected %q", placeholder, e)
 		}
 	}
 
@@ -928,7 +928,7 @@ func TestFindLinks(t *testing.T) {
 	if !typOk {
 		t.Fatalf("[.container form input] Failed to find type attribute")
 	} else if typ != "submit" {
-		t.Fatalf("[.container form input] Type mismatch got '%s', expected 'submit'", typ)
+		t.Fatalf("[.container form input] Type mismatch got '%q', expected 'submit'", typ)
 	}
 
 	//
@@ -972,7 +972,7 @@ func TestAddLinks(t *testing.T) {
 		text := strings.TrimSpace(sel.Text())
 		e := "Add Links"
 		if text != e {
-			t.Fatalf("[.container h2] Header mismatch got '%s', expected '%s'", text, e)
+			t.Fatalf("[.container h2] Header mismatch got '%q', expected '%q'", text, e)
 		}
 	})
 
@@ -987,7 +987,7 @@ func TestAddLinks(t *testing.T) {
 	} else {
 		e := "Enter links: one per line"
 		if placeholder != e {
-			t.Fatalf("[.container form textarea] Bad placeholder attribute got %s, expected %s", placeholder, e)
+			t.Fatalf("[.container form textarea] Bad placeholder attribute got %q, expected %q", placeholder, e)
 		}
 	}
 
@@ -999,7 +999,7 @@ func TestAddLinks(t *testing.T) {
 	if !typOk {
 		t.Fatalf("[.container form input[type=submit]] Failed to find type attribute")
 	} else if typ != "submit" {
-		t.Fatalf("[.container form input[type=submit]] Bad type got %s, expected submit", typ)
+		t.Fatalf("[.container form input[type=submit]] Bad type got %q, expected submit", typ)
 	}
 
 	input = form.Find("input[type=checkbox]")
@@ -1010,14 +1010,14 @@ func TestAddLinks(t *testing.T) {
 	if !typOk {
 		t.Fatalf("[.container form input[type=checkbox]] Failed to find type attribute")
 	} else if typ != "checkbox" {
-		t.Fatalf("[.container form input[type=checkbox]] Bad type got %s, expected checkbox", typ)
+		t.Fatalf("[.container form input[type=checkbox]] Bad type got %q, expected checkbox", typ)
 	}
 
 	//
 	// Submit an add request
 	//
 	randDomain := fmt.Sprintf("rand%d.com", rand.Uint32())
-	randLink := fmt.Sprintf("http://sub.%s.com/page0.html", randDomain)
+	randLink := fmt.Sprintf("http://sub.%q.com/page0.html", randDomain)
 	rawBody := "links=" + randLink + "%0D%0A"
 	doc, body, status = callController("http://localhost:3000/add", rawBody, "/add", console.AddLinkIndexController)
 	if status != http.StatusOK {


### PR DESCRIPTION
From the ticket:

* When looking at the /historical/... info page for a link, the link header itself should lead to the target site and there should be a link to get to the domain info page for that link
* When paging through links in a domain, there should be a link to return to the domain info page

Cover these two points. Tests pass and I have reviewed visually on my dev install. Let me know - particularly if ther eis a visual style gude - I'm no designer and may have violated such rules :smile: 