### PR TITLE
Trn 606 dispatch one shot

### DIFF
--- a/cassandra/dispatcher.go
+++ b/cassandra/dispatcher.go
@@ -57,7 +57,7 @@ type Dispatcher struct {
 
 	// If true, this field signals that this dispatcher run should quit as soon as all
 	// available work is done.
-	enableOneShot bool
+	oneShotIterations int
 }
 
 // StartDispatcher starts the dispatcher
@@ -102,8 +102,11 @@ func (d *Dispatcher) StartDispatcher() error {
 	return nil
 }
 
-func (d *Dispatcher) oneShot() error {
-	d.enableOneShot = true
+func (d *Dispatcher) oneShot(iterations int) error {
+	if iterations <= 0 {
+		return fmt.Errorf("Argument to oneShot must be > 0")
+	}
+	d.oneShotIterations = iterations
 	err := d.StartDispatcher()
 	if err != nil {
 		d.StopDispatcher()
@@ -209,7 +212,9 @@ func (d *Dispatcher) fetcherIsAlive(claimTok gocql.UUID) bool {
 }
 
 func (d *Dispatcher) domainIterator() {
+	iteration := 0
 	for {
+		iteration++
 		log4go.Debug("Starting new domain iteration")
 		domainiter := d.db.Query(`SELECT dom, dispatched, claim_tok, excluded FROM domain_info`).Iter()
 
@@ -226,7 +231,7 @@ func (d *Dispatcher) domainIterator() {
 			if !dispatched && !excluded {
 				d.domains <- domain
 			} else if !d.fetcherIsAlive(claimTok) {
-				if !d.enableOneShot {
+				if d.oneShotIterations == 0 {
 					go d.cleanStrandedClaims(claimTok)
 				} else {
 					d.cleanStrandedClaims(claimTok)
@@ -242,7 +247,8 @@ func (d *Dispatcher) domainIterator() {
 		// Check for quit signal right away, otherwise if there are no domains
 		// to claim and the dispatchInterval is 0, then the dispatcher will
 		// never quit
-		if d.enableOneShot || d.quitSignaled() {
+		osi := d.oneShotIterations
+		if (osi > 0 && iteration >= osi) || d.quitSignaled() {
 			close(d.domains)
 			return
 		}


### PR DESCRIPTION
We have ongoing issues with timed tests in the dispatcher (and fetcher, and other) test code. These issues manifest as tests reporting false negatives, that are corrected with rerun. The problem is particularly noticeable on the travis system, which runs slower than our cpod machines, and hence more likely time-limits a test. This patch will add a oneShot method to the dispatcher, which will synchronously run the dispatcher until all the available links are dispatched, and then return. With one shot we can replace test code that looks like this