### PR TITLE
Silenced the data-race detector in TRN_290_race_detect.

### DIFF
--- a/cassandra/dispatcher.go
+++ b/cassandra/dispatcher.go
@@ -35,7 +35,7 @@ type Dispatcher struct {
 
 	// synchronizes generators that are currently working, so we can wait for
 	// them to finish before we start a new domain iteration
-	generatingLock sync.Mutex
+	generatingWG sync.WaitGroup
 
 	// do not dispatch any link that has been crawled within this amount of
 	// time; set by dispatcher.min_link_refresh_time config parameter
@@ -312,10 +312,7 @@ func (d *Dispatcher) domainIterator() {
 		if err := domainiter.Close(); err != nil {
 			log4go.Error("Error iterating domains from domain_info: %v", err)
 		}
-
-		// Syncronize with generateRoutine()
-		d.generatingLock.Lock()
-		d.generatingLock.Unlock()
+		d.generatingWG.Wait()
 
 		// Check for quit signal right away, otherwise if there are no domains
 		// to claim and the dispatchInterval is 0, then the dispatcher will
@@ -351,11 +348,11 @@ func (d *Dispatcher) quitSignaled() bool {
 
 func (d *Dispatcher) generateRoutine() {
 	for domain := range d.domains {
-		d.generatingLock.Lock()
+		d.generatingWG.Add(1)
 		if err := d.generateSegment(domain); err != nil {
 			log4go.Error("error generating segment for %v: %v", domain, err)
 		}
-		d.generatingLock.Unlock()
+		d.generatingWG.Done()
 	}
 	log4go.Debug("Finishing generateRoutine")
 }

--- a/fetcher.go
+++ b/fetcher.go
@@ -117,9 +117,9 @@ type FetchManager struct {
 	keepAliveQuit chan struct{}
 
 	// These variables explicitly synchornized. See started() and fetchers()
-	mu        sync.Mutex
-	_started  bool
-	_fetchers []*fetcher
+	sharedVarMutex sync.Mutex
+	_started       bool
+	_fetchers      []*fetcher
 
 	// If this flag is set, oneShot is set on each child fetcher
 	oneShot bool
@@ -320,26 +320,26 @@ func (fm *FetchManager) Stop() {
 }
 
 func (fm *FetchManager) started() bool {
-	fm.mu.Lock()
-	defer fm.mu.Unlock()
+	fm.sharedVarMutex.Lock()
+	defer fm.sharedVarMutex.Unlock()
 	return fm._started
 }
 
 func (fm *FetchManager) setStarted(started bool) {
-	fm.mu.Lock()
-	defer fm.mu.Unlock()
+	fm.sharedVarMutex.Lock()
+	defer fm.sharedVarMutex.Unlock()
 	fm._started = started
 }
 
 func (fm *FetchManager) fetchers() []*fetcher {
-	fm.mu.Lock()
-	defer fm.mu.Unlock()
+	fm.sharedVarMutex.Lock()
+	defer fm.sharedVarMutex.Unlock()
 	return fm._fetchers
 }
 
 func (fm *FetchManager) setFetchers(fetchers []*fetcher) {
-	fm.mu.Lock()
-	defer fm.mu.Unlock()
+	fm.sharedVarMutex.Lock()
+	defer fm.sharedVarMutex.Unlock()
 	fm._fetchers = fetchers
 }
 

--- a/fetcher.go
+++ b/fetcher.go
@@ -102,9 +102,7 @@ type FetchManager struct {
 	// Parsed duration of the string Config.Fetcher.HTTPKeepAliveThreshold
 	KeepAliveThreshold time.Duration
 
-	fetchers  []*fetcher
 	fetchWait sync.WaitGroup
-	started   bool
 
 	// used to match Content-Type headers
 	acceptFormats *mimetools.Matcher
@@ -117,6 +115,11 @@ type FetchManager struct {
 
 	// close this channel to kill the keep-alive thread
 	keepAliveQuit chan struct{}
+
+	// These variables explicitly synchornized. See started() and fetchers()
+	mu        sync.Mutex
+	_started  bool
+	_fetchers []*fetcher
 }
 
 // Start begins processing assuming that the datastore and any handlers have
@@ -132,7 +135,7 @@ func (fm *FetchManager) Start() {
 	if fm.Handler == nil {
 		panic("Cannot start a FetchManager without a handler")
 	}
-	if fm.started {
+	if fm.started() {
 		panic("Cannot start a FetchManager multiple times")
 	}
 
@@ -186,8 +189,6 @@ func (fm *FetchManager) Start() {
 			}
 		}
 	}()
-
-	fm.started = true
 
 	timeout, err := time.ParseDuration(Config.Fetcher.HTTPTimeout)
 	if err != nil {
@@ -258,16 +259,20 @@ func (fm *FetchManager) Start() {
 	}
 
 	numFetchers := Config.Fetcher.NumSimultaneousFetchers
-	fm.fetchers = make([]*fetcher, numFetchers)
+	fetchers := make([]*fetcher, numFetchers)
+
 	for i := 0; i < numFetchers; i++ {
 		f := newFetcher(fm)
-		fm.fetchers[i] = f
+		fetchers[i] = f
 		fm.fetchWait.Add(1)
 		go func() {
 			f.start()
 			fm.fetchWait.Done()
 		}()
 	}
+	fm.setFetchers(fetchers)
+	fm.setStarted(true)
+
 	fm.fetchWait.Wait()
 }
 
@@ -275,14 +280,38 @@ func (fm *FetchManager) Start() {
 // all fetchers have finished.
 func (fm *FetchManager) Stop() {
 	log4go.Info("Stopping FetchManager")
-	if !fm.started {
+	if !fm.started() {
 		panic("Cannot stop a FetchManager that has not been started")
 	}
-	for _, f := range fm.fetchers {
+	for _, f := range fm.fetchers() {
 		go f.stop()
 	}
 	close(fm.keepAliveQuit)
 	fm.fetchWait.Wait()
+}
+
+func (fm *FetchManager) started() bool {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+	return fm._started
+}
+
+func (fm *FetchManager) setStarted(started bool) {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+	fm._started = started
+}
+
+func (fm *FetchManager) fetchers() []*fetcher {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+	return fm._fetchers
+}
+
+func (fm *FetchManager) setFetchers(fetchers []*fetcher) {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+	fm._fetchers = fetchers
 }
 
 // fetcher encompasses one of potentially many fetchers the FetchManager may

--- a/helpers.go
+++ b/helpers.go
@@ -177,10 +177,11 @@ func (sc *stallingConn) Write(b []byte) (int, error) {
 }
 
 func (sc *stallingConn) Close() error {
-	if !sc.closed {
+	select {
+	case <-sc.quit:
+	default:
 		close(sc.quit)
 	}
-	sc.closed = true
 	return nil
 }
 

--- a/semaphore/semaphore.go
+++ b/semaphore/semaphore.go
@@ -1,0 +1,48 @@
+/*
+   A semaphore that doesn't trip up the race detector like WaitGroup does.
+*/
+package semaphore
+
+import (
+	"sync"
+)
+
+type Semaphore struct {
+	cond  *sync.Cond
+	lock  sync.Mutex
+	count int
+}
+
+func New() *Semaphore {
+	s := &Semaphore{}
+	s.cond = sync.NewCond(&s.lock)
+	return s
+}
+
+func (sm *Semaphore) Reset() {
+	sm.count = 0
+	sm.cond.Broadcast()
+}
+
+func (sm *Semaphore) Add(i int) {
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
+
+	sm.count += i
+	if sm.count <= 0 {
+		sm.cond.Broadcast()
+	}
+}
+
+func (sm *Semaphore) Done() {
+	sm.Add(-1)
+}
+
+func (sm *Semaphore) Wait() {
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
+
+	for sm.count <= 0 {
+		sm.cond.Wait()
+	}
+}

--- a/semaphore/semaphore_test.go
+++ b/semaphore/semaphore_test.go
@@ -1,0 +1,61 @@
+package semaphore
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSemaphore(t *testing.T) {
+	numbers := []int{}
+	negatives := []int{}
+	for i := 1; i < 1000; i++ {
+		numbers = append(numbers, i)
+		negatives = append(negatives, -i)
+	}
+	numbers = append(numbers, negatives...)
+	semaphore := New()
+	type Ent struct {
+		done bool
+		num  int
+	}
+	numChan := make(chan Ent)
+
+	// Fork off routines to publish numbers
+	goRoutineCount := 10
+	for i := 0; i < goRoutineCount; i++ {
+		go func() {
+			for {
+				ent := <-numChan
+				if ent.done {
+					return
+				}
+				semaphore.Add(ent.num)
+			}
+		}()
+	}
+
+	//detect allGood
+	allDone := make(chan bool)
+	go func() {
+		semaphore.Wait()
+		allDone <- true
+	}()
+
+	// send the numbers off
+	for _, n := range numbers {
+		numChan <- Ent{false, n}
+	}
+
+	// send the end markers
+	for i := 0; i < goRoutineCount; i++ {
+		numChan <- Ent{true, 0}
+	}
+
+	// wait for allGood
+	duration, _ := time.ParseDuration("100ms")
+	select {
+	case <-allDone:
+	case <-time.After(duration):
+		t.Fatalf("Did not get allGood message")
+	}
+}


### PR DESCRIPTION
https://jira2.iparadigms.com/browse/TRN-290:

I ran the race detector (http://golang.org/doc/articles/race_detector.html) once on our tests and it found a few, we should look into possible data race conditions it finds, see if they are valid, and schedule work to fix them (or fix them if they are easy).

---

So very small patch here. I'm not arguing that these changes are essential: the usage pattern of some of these variables, that are now protected, precludes problems. But, the program is more correct with these changes, and this will silence the race-detector on these issues in the future. Sadly the race detector falsely identifies calls to WaitGroup objects as data races -- but WaitGroup is thread safe.