### PR TITLE
Trn 590 schema diff

### DIFF
--- a/script/schema_diff.sh
+++ b/script/schema_diff.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# set the shell to die for any command that returns non-zero
+set -e 
+
+## Usage info
+show_help() {
+cat << EOF
+Usage: ${0##*/} [-hk] <HOST> <PORT>
+Description:
+    Produce a diff of schema in THIS walker repo, and a running cassandra node. Note that the local schema
+    is on the left in the diff, and the cassandra node schema is on the right.
+DIAGNOSTIC NOTES:
+    * Must run out of the main walker directory.
+    * cqlsh must be in your current path.
+Example:
+    schema_diff 127.0.0.1 9042
+Arguments:
+    HOST: Mandatory. Specify the host that the running cassandra node is on
+    PORT: Mandatory. Specify the port that the running cassandra node is on
+Options:
+    -h: Display this help and exit
+    -k: Write two schema files into this directory. One file is the schema for the local repo, called local.txt. And the
+        second files store the schema for the live cassandra source: it is called live.txt. 
+EOF
+}
+
+die(){
+    show_help >&2
+    echo "ERROR:" >&2
+    echo $1 >&2
+    exit 1 
+}
+
+
+## Set up file names: could be overridden by -k
+LEFT_FILE=/tmp/walker_schema_diff.$$.1.txt
+RIGHT_FILE=/tmp/walker_schema_diff.$$.2.txt
+DELETE_FILES=1
+
+## Have at the options
+while getopts "hk" opt; do
+    case "$opt" in
+        h)  show_help
+            exit 0
+            ;;
+        k)  LEFT_FILE='local.txt'
+            RIGHT_FILE='live.txt'
+            DELETE_FILES=0
+            ;;
+        '?')
+            die "Unknown option $OPTARG"
+            ;;
+    esac
+done
+shift $(($OPTIND - 1)) # set so $1==host and $2==port
+
+## Make sure the arguments where passed in
+if [ -z "$1" ]
+then
+    die "Failed to specify HOST and PORT"
+fi
+HOST=$1
+
+if [ -z "$2" ]
+then
+    die "Failed to specify PORT"
+fi
+PORT=$2
+
+## Let's execute
+go run walker/main.go schema -o $LEFT_FILE
+cqlsh -k walker -e 'describe schema' $HOST $PORT > $RIGHT_FILE
+diff $LEFT_FILE $RIGHT_FILE
+
+if [ $DELETE_FILES -eq "1" ]
+then
+rm -f $LEFT_FILE $RIGHT_FILE
+fi

--- a/script/schema_diff.sh
+++ b/script/schema_diff.sh
@@ -21,7 +21,7 @@ Arguments:
 Options:
     -h: Display this help and exit
     -k: Write two schema files into this directory. One file is the schema for the local repo, called local.txt. And the
-        second files store the schema for the live cassandra source: it is called live.txt. 
+        second file stores the schema for the live cassandra source: it is called live.txt. 
 EOF
 }
 

--- a/script/schema_diff.sh
+++ b/script/schema_diff.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
-# set the shell to die for any command that returns non-zero
+## set the shell to die for any command that returns non-zero
 set -e 
 
 ## Usage info
 show_help() {
 cat << EOF
-Usage: ${0##*/} [-hk] <HOST> <PORT>
+Usage: schema_diff.sh [-hk] <HOST> <PORT>
 Description:
     Produce a diff of schema in THIS walker repo, and a running cassandra node. Note that the local schema
     is on the left in the diff, and the cassandra node schema is on the right.
-DIAGNOSTIC NOTES:
+Diagnostic Notes:
     * Must run out of the main walker directory.
     * cqlsh must be in your current path.
 Example:
@@ -25,6 +25,7 @@ Options:
 EOF
 }
 
+## echo help and error message to stderr
 die(){
     show_help >&2
     echo "ERROR:" >&2

--- a/script/schema_diff.sh
+++ b/script/schema_diff.sh
@@ -71,7 +71,7 @@ PORT=$2
 
 ## Let's execute
 go run walker/main.go schema -o $LEFT_FILE
-cqlsh -k walker -e 'describe schema' $HOST $PORT > $RIGHT_FILE
+cqlsh -k walker -e 'describe keyspace walker' $HOST $PORT > $RIGHT_FILE
 diff $LEFT_FILE $RIGHT_FILE
 
 if [ $DELETE_FILES -eq "1" ]


### PR DESCRIPTION
https://jira2.iparadigms.com/browse/TRN-590

As an operator/advanced user,
I want to be able to run a script in Walker that shows the diff of the live Cassandra node and current Walker version,
so that I don't have to search for and make DB changes manually on the live cluster when the schema has changed.
Acceptance Criteria:
1. Script has proven to return differences in live schema when they exist
2. Script fetches data on schema ( addition & removal of columns, changes in column/field definitions
3. Output: Old school diff (not aware of semantics). Text diff
__________________________________________________________________________________________________________
Technical Details:
Currently the way we handle database changes on the live cluster is: I look at merged pull requests and make necessary db changes by hand when the schema has changed. DB migrations are hard with cassandra especially because some deployment-specific information, like replication strategy, is part of the schema. On top of that, some database changes may be better done when there is no load on the cluster (like compaction changes). So for the time being we won't bother with migrations.
Instead, as an operator and advanced user I want a script (something in walker/script is okay) that takes the host/port of a live cassandra node and compares it's schema against the schema that would be produced by the current walker version, and shows me a nice-looking diff.