### PR TITLE
Trn 270 link normal config

### DIFF
--- a/config.go
+++ b/config.go
@@ -61,15 +61,21 @@ type ConfigStruct struct {
 		HTTPKeepAlive            string   `yaml:"http_keep_alive"`
 		HTTPKeepAliveThreshold   string   `yaml:"http_keep_alive_threshold"`
 		MaxPathLength            int      `yaml:"max_path_length"`
+
+		UrlNormalizations struct {
+			RemoveDotSegments      bool `yaml:"remove dot segments"`
+			RemoveDuplicateSlashes bool `yaml:"remove duplicate slashes"`
+		} `yaml:"url_normalizations"`
 	} `yaml:"fetcher"`
 
 	Dispatcher struct {
-		MaxLinksPerSegment       int     `yaml:"num_links_per_segment"`
-		RefreshPercentage        float64 `yaml:"refresh_percentage"`
-		NumConcurrentDomains     int     `yaml:"num_concurrent_domains"`
-		MinLinkRefreshTime       string  `yaml:"min_link_refresh_time"`
-		DispatchInterval         string  `yaml:"dispatch_interval"`
-		CorrectLinkNormalization bool    `yaml:"correct_link_normalization"`
+		MaxLinksPerSegment         int     `yaml:"num_links_per_segment"`
+		RefreshPercentage          float64 `yaml:"refresh_percentage"`
+		NumConcurrentDomains       int     `yaml:"num_concurrent_domains"`
+		MinLinkRefreshTime         string  `yaml:"min_link_refresh_time"`
+		DispatchInterval           string  `yaml:"dispatch_interval"`
+		CorrectLinkNormalization   bool    `yaml:"correct_link_normalization"`
+		EmptyDispatchRetryInterval string  `yaml:"empty_dispatch_retry_interval"`
 	} `yaml:"dispatcher"`
 
 	Cassandra struct {
@@ -142,6 +148,8 @@ func SetDefaultConfig() {
 	Config.Fetcher.HTTPKeepAlive = "always"
 	Config.Fetcher.HTTPKeepAliveThreshold = "15s"
 	Config.Fetcher.MaxPathLength = 2048
+	Config.Fetcher.UrlNormalizations.RemoveDotSegments = true
+	Config.Fetcher.UrlNormalizations.RemoveDuplicateSlashes = true
 
 	Config.Dispatcher.MaxLinksPerSegment = 500
 	Config.Dispatcher.RefreshPercentage = 25
@@ -149,6 +157,7 @@ func SetDefaultConfig() {
 	Config.Dispatcher.MinLinkRefreshTime = "0s"
 	Config.Dispatcher.DispatchInterval = "10s"
 	Config.Dispatcher.CorrectLinkNormalization = false
+	Config.Dispatcher.EmptyDispatchRetryInterval = "0s"
 
 	Config.Cassandra.Hosts = []string{"localhost"}
 	Config.Cassandra.Keyspace = "walker"
@@ -210,6 +219,10 @@ func assertConfigInvariants() error {
 	_, err = time.ParseDuration(dis.DispatchInterval)
 	if err != nil {
 		errs = append(errs, fmt.Sprintf("Dispatcher.DispatchInterval failed to parse: %v", err))
+	}
+	_, err = time.ParseDuration(dis.EmptyDispatchRetryInterval)
+	if err != nil {
+		errs = append(errs, fmt.Sprintf("Dispatcher.EmptyDispatchRetryInterval failed to parse: %v", err))
 	}
 
 	fet := &Config.Fetcher

--- a/config.go
+++ b/config.go
@@ -63,8 +63,8 @@ type ConfigStruct struct {
 		MaxPathLength            int      `yaml:"max_path_length"`
 
 		UrlNormalizations struct {
-			RemoveDotSegments      bool `yaml:"remove dot segments"`
-			RemoveDuplicateSlashes bool `yaml:"remove duplicate slashes"`
+			RemoveDotSegments      bool `yaml:"remove_dot_segments"`
+			RemoveDuplicateSlashes bool `yaml:"remove_duplicate_slashes"`
 		} `yaml:"url_normalizations"`
 	} `yaml:"fetcher"`
 

--- a/fetcher_test.go
+++ b/fetcher_test.go
@@ -733,6 +733,9 @@ func TestBasicLinkTest(t *testing.T) {
 	}()
 	Config.Fetcher.AcceptFormats = []string{"text/html", "text/plain"}
 
+	Config.Fetcher.UrlNormalizations.RemoveDotSegments = true
+	PostConfigHooks()
+
 	const html_test_links string = `<!DOCTYPE html>
 <html>
 <head>

--- a/fetcher_test.go
+++ b/fetcher_test.go
@@ -733,9 +733,6 @@ func TestBasicLinkTest(t *testing.T) {
 	}()
 	Config.Fetcher.AcceptFormats = []string{"text/html", "text/plain"}
 
-	Config.Fetcher.UrlNormalizations.RemoveDotSegments = true
-	PostConfigHooks()
-
 	const html_test_links string = `<!DOCTYPE html>
 <html>
 <head>

--- a/url.go
+++ b/url.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"code.google.com/p/go.net/publicsuffix"
-	"code.google.com/p/log4go"
 	"github.com/PuerkitoBio/purell"
 )
 
@@ -103,14 +102,11 @@ func ParseURL(ref string) (*URL, error) {
 // ParseAndNormalizeURL will walker.ParseURL the argument string,
 // and then Normalize the resulting URL.
 func ParseAndNormalizeURL(ref string) (*URL, error) {
-	log4go.Error("PETE input ref %v", ref)
 	u, err := ParseURL(ref)
 	if err != nil {
 		return u, err
 	}
-	log4go.Error("PETE output url %v", u.String())
 	u.Normalize()
-	log4go.Error("PETE post normal url %v", u.String())
 	return u, nil
 }
 

--- a/url.go
+++ b/url.go
@@ -79,10 +79,10 @@ func setupNormalizeURL() error {
 
 	normalizationFlags = purell.FlagsSafe | purell.FlagRemoveFragment
 	if Config.Fetcher.UrlNormalizations.RemoveDotSegments {
-		normalizationFlags = normalizationFlags | purell.RemoveDotSegments
+		normalizationFlags = normalizationFlags | purell.FlagRemoveDotSegments
 	}
 	if Config.Fetcher.UrlNormalizations.RemoveDuplicateSlashes {
-		normalizationFlags = normalizationFlags | purell.RemoveTrailingSlash
+		normalizationFlags = normalizationFlags | purell.FlagRemoveDuplicateSlashes
 	}
 
 	return nil

--- a/url.go
+++ b/url.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"code.google.com/p/go.net/publicsuffix"
+	"code.google.com/p/log4go"
 	"github.com/PuerkitoBio/purell"
 )
 
@@ -102,11 +103,14 @@ func ParseURL(ref string) (*URL, error) {
 // ParseAndNormalizeURL will walker.ParseURL the argument string,
 // and then Normalize the resulting URL.
 func ParseAndNormalizeURL(ref string) (*URL, error) {
+	log4go.Error("PETE input ref %v", ref)
 	u, err := ParseURL(ref)
 	if err != nil {
 		return u, err
 	}
+	log4go.Error("PETE output url %v", u.String())
 	u.Normalize()
+	log4go.Error("PETE post normal url %v", u.String())
 	return u, nil
 }
 

--- a/walker.yaml
+++ b/walker.yaml
@@ -110,6 +110,12 @@ fetcher:
     # ignore URI path length.
     max_path_length: 2048
 
+    ## walker always applies all safe URL normalizations to each URL. The normalizations below are potentially unsafe,
+    ## but generally safe. Set the value of these options to false to turn the normalization off.
+    url_normalizations:
+        remove dot segments: true
+        remove duplicate slashes: true
+
 # Dispatcher configuration
 dispatcher:
     # maximum number of links added to segments table per dispatch (must be >0)

--- a/walker.yaml
+++ b/walker.yaml
@@ -113,8 +113,8 @@ fetcher:
     ## walker always applies all safe URL normalizations to each URL. The normalizations below are potentially unsafe,
     ## but generally safe. Set the value of these options to false to turn the normalization off.
     url_normalizations:
-        remove dot segments: true
-        remove duplicate slashes: true
+        remove_dot_segments: true
+        remove_duplicate_slashes: true
 
 # Dispatcher configuration
 dispatcher:


### PR DESCRIPTION
Implementation of https://jira2.iparadigms.com/browse/TRN-270.

--start ticket
Currently we use https://github.com/PuerkitoBio/purell to normalize links and it seems to work well. We use the safest normalizations but could gain from using some of the others (for example removing dot segments from paths, http://host/path/./a/b/../c -> http://host/path/a/c).
We should also add a configuration item so Walker operators can choose from a few basic levels of link normalization. I don't think we need to provide every flag available in purell because some of those filters we would never want (ex. removing the directory index) and might break Walker so should not be used. However it might be good to allow the user to configure "no normalization", "basic normalization", and "aggressive normalization" or something along those lines. I think by default we'd want aggressive.
Acceptance Criteria;
-URLS can be normalized for remove dot segments and remove duplicate slashes
-it is user configurable in the configuration file
Remaining tasks:
implement it
--end

QUESTION: Since walker is closed source now, I'm wondering if we need to reproduce the ticket in the PR (rather than just providing the ticket link). @cgilling what do you think?

NOTE: The impl of this requires a patch to github.com/PuerkitoBio/purell that looks like this:
```
--- a/purell.go
+++ b/purell.go
@@ -231,7 +231,7 @@ func removeDotSegments(u *url.URL) {
                }
                // Special case if host does not end with / and new path does not begin with /
                u.Path = strings.Join(dotFree, "/")
-               if !strings.HasSuffix(u.Host, "/") && !strings.HasPrefix(u.Path, "/") {
+               if u.Host != "" && !strings.HasSuffix(u.Host, "/") && !strings.HasPrefix(u.Path, "/") {
                        u.Path = "/" + u.Path
                }
```

That patch will be pushed upstream to the purell developer shortly.