### PR TITLE
README: Simple fix to `go get` instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ have crawled so far.
 Make sure you have [go installed and a GOPATH set](https://golang.org/doc/install):
 
 ```sh
-go get github.com/iParadigms/walker
+go get github.com/iParadigms/walker/...
 ```
 
 To get going quickly, you need to install Cassandra. A simple install of


### PR DESCRIPTION
Simple fix to the instructions that came up during Swathi's testing. This fix will cause all the appropriate packages to be downloaded automatically and the walker binary to be built in $GOPATH/bin